### PR TITLE
fix error for too long channel names

### DIFF
--- a/kilian.py
+++ b/kilian.py
@@ -73,12 +73,10 @@ if __name__ == '__main__':
 
             added_roles = Roles()
             for course_name in missing_courses_by_name:
-                role = await ctx.guild.create_role(
-                    (course_name[:90] + '...') if len(course_name) > 92 else course_name
-                )
+                role = await ctx.guild.create_role(course_name[:95] if len(course_name) > 95 else course_name)
 
                 channel = await ctx.guild.create_channel(
-                    name=((course_name[:90] + '...') if len(course_name) > 92 else course_name),
+                    name=(course_name[:95] if len(course_name) > 95 else course_name),
                     type=interactions.ChannelType.GUILD_TEXT,
                     parent_id=category)
                 added_roles.add((course_name, uni.current_semester(), guild_id, str(role.id), str(channel.id)))

--- a/kilian.py
+++ b/kilian.py
@@ -73,9 +73,12 @@ if __name__ == '__main__':
 
             added_roles = Roles()
             for course_name in missing_courses_by_name:
-                role = await ctx.guild.create_role(course_name)
+                role = await ctx.guild.create_role(
+                    (course_name[:90] + '...') if len(course_name) > 92 else course_name
+                )
+
                 channel = await ctx.guild.create_channel(
-                    name=course_name,
+                    name=((course_name[:90] + '...') if len(course_name) > 92 else course_name),
                     type=interactions.ChannelType.GUILD_TEXT,
                     parent_id=category)
                 added_roles.add((course_name, uni.current_semester(), guild_id, str(role.id), str(channel.id)))


### PR DESCRIPTION
* limit channel/role length to 95 characters if they are too long (Discord limit is 100)