### PR TITLE
Allow Dad IDs to be numeric

### DIFF
--- a/kilian.py
+++ b/kilian.py
@@ -294,7 +294,7 @@ if __name__ == '__main__':
     async def sleep(ctx: interactions.CommandContext):
         """Make Kilian go nighty night."""
 
-        if dads.count(str(ctx.author.id)):
+        if dads.count(ctx.author.id):
             await ctx.send("Good night, daddy!", ephemeral=True)
             await bot._stop()
         else:


### PR DESCRIPTION
This way of checking if a user-id is a dad allows the value in the config to be a string or numeric number. This allows to keep backwards compatibility but also allow IDs as numeric values.